### PR TITLE
Fix ActiveRecord translate_error API

### DIFF
--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -168,7 +168,7 @@ module ActiveRecord
 
       # Translate an exception from the native DBMS to something usable by
       # ActiveRecord.
-      def translate_exception(exception, message)
+      def translate_exception(exception, message:, sql:, binds:)
         error_number = exception.message[/^\d+/].to_i
 
         if error_number == ERR_DUPLICATE_KEY_VALUE


### PR DESCRIPTION
Executing an ODBC command with a SQL of database level error caused a broken integration with ActiveRecord >= 6.x

*Before:*
```
ArgumentError: wrong number of arguments (given 2, expected 1; required keywords: message, sql, binds)
from /srv/app/lello/vendor/bundle/ruby/3.1.0/gems/activerecord-6.1.7.7/lib/active_record/connection_adapters/abstract_adapter.rb:703:in `translate_exception'
Caused by ODBC::Error: 37000 (904) SQL compilation error: error line 1 at position 7
invalid identifier 'OHNO'
from /srv/app/lello/vendor/bundle/ruby/3.1.0/bundler/gems/odbc_adapter-19efd2c52a0d/lib/odbc_adapter/database_statements.rb:29:in `run'
```

*After:*
```
ActiveRecord::StatementInvalid: ODBC::Error: 37000 (904) SQL compilation error: error line 1 at position 7
invalid identifier 'OHNO'
from /srv/app/lello/vendor/bundle/ruby/3.1.0/bundler/gems/odbc_adapter-e616f8a27fa0/lib/odbc_adapter/database_statements.rb:29:in `run'
Caused by ODBC::Error: 37000 (904) SQL compilation error: error line 1 at position 7
invalid identifier 'OHNO'
from /srv/app/lello/vendor/bundle/ruby/3.1.0/bundler/gems/odbc_adapter-e616f8a27fa0/lib/odbc_adapter/database_statements.rb:29:in `run'
```