### PR TITLE
Rails 7.1 compatibility hack

### DIFF
--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -81,6 +81,8 @@ module ActiveRecord
         configure_time_options(connection)
         super(connection, logger, config)
         @database_metadata = database_metadata
+        # This sets the @connection ivar to the old expected value on newer versions of Rails (7.1+)
+        @connection ||= @raw_connection
       end
 
       # Returns the human-readable name of the adapter.

--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -82,7 +82,7 @@ module ActiveRecord
         super(connection, logger, config)
         @database_metadata = database_metadata
         # This sets the @connection ivar to the old expected value on newer versions of Rails (7.1+)
-        @connection ||= @raw_connection
+        @connection ||= @unconfigured_connection
       end
 
       # Returns the human-readable name of the adapter.


### PR DESCRIPTION
This adds an or-equals set of `@connection` to `@unconfigured_connection` if it isn't set post `super()`. https://github.com/rails/rails/commit/d86fd6415c0dfce6fadb77e74696cf728e5eb76b changes the name of that ivar in AbstractAdapter and in stable 7-1 https://github.com/rails/rails/blob/7-1-stable/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb it has been changed yet again!