### PR TITLE
Support ActiveRecord 6.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         ruby: [2.6]
         gemfile:
-          - ar_5_2
+          - ar_6_0
     services:
       postgres:
         image: postgres:16

--- a/Appraisals
+++ b/Appraisals
@@ -1,3 +1,3 @@
-appraise "ar_5_2" do
-  gem 'activerecord', '~> 5.2.1'
+appraise "ar_6_0" do
+  gem 'activerecord', '~> 6.0.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'activerecord', '>= 5.2.1'
+gem 'activerecord', '>= 6.0.0'

--- a/gemfiles/ar_6_0.gemfile
+++ b/gemfiles/ar_6_0.gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
-gem 'activerecord', '~> 5.2.1'
+gem 'activerecord', '~> 6.0.0'
 
 gemspec path: "../"

--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -127,8 +127,8 @@ module ActiveRecord
       # Build a new column object from the given options. Effectively the same
       # as super except that it also passes in the native type.
       # rubocop:disable Metrics/ParameterLists
-      def new_column(name, default, sql_type_metadata, null, table_name, default_function = nil, collation = nil, native_type = nil)
-        ::ODBCAdapter::Column.new(name, default, sql_type_metadata, null, table_name, default_function, collation, native_type)
+      def new_column(name, default, sql_type_metadata, null, native_type = nil)
+        ::ODBCAdapter::Column.new(name, default, sql_type_metadata, null, native_type)
       end
 
       protected

--- a/lib/odbc_adapter/adapters/postgresql_odbc_adapter.rb
+++ b/lib/odbc_adapter/adapters/postgresql_odbc_adapter.rb
@@ -35,7 +35,7 @@ module ODBCAdapter
         "#{table_name}_#{pk || 'id'}_seq"
       end
 
-      def sql_for_insert(sql, pk, _id_value, _sequence_name, binds)
+      def sql_for_insert(sql, pk, binds)
         unless pk
           table_ref = extract_table_ref_from_insert_sql(sql)
           pk = primary_key(table_ref) if table_ref

--- a/lib/odbc_adapter/column.rb
+++ b/lib/odbc_adapter/column.rb
@@ -5,8 +5,8 @@ module ODBCAdapter
     # Add the native_type accessor to allow the native DBMS to report back what
     # it uses to represent the column internally.
     # rubocop:disable Metrics/ParameterLists
-    def initialize(name, default, sql_type_metadata = nil, null = true, table_name = nil, native_type = nil, default_function = nil, collation = nil)
-      super(name, default, sql_type_metadata, null, table_name, default_function, collation)
+    def initialize(name, default, sql_type_metadata = nil, null = true, native_type = nil, **kwargs)
+      super(name, default, sql_type_metadata, null, **kwargs)
       @native_type = native_type
     end
   end

--- a/lib/odbc_adapter/schema_statements.rb
+++ b/lib/odbc_adapter/schema_statements.rb
@@ -83,7 +83,7 @@ module ODBCAdapter
         end
         sql_type_metadata = ActiveRecord::ConnectionAdapters::SqlTypeMetadata.new(**args)
 
-        cols << new_column(format_case(col_name), col_default, sql_type_metadata, col_nullable, table_name, col_native_type)
+        cols << new_column(format_case(col_name), col_default, sql_type_metadata, col_nullable, col_native_type)
       end
     end
 

--- a/lib/odbc_adapter/version.rb
+++ b/lib/odbc_adapter/version.rb
@@ -1,3 +1,3 @@
 module ODBCAdapter
-  VERSION = '5.0.4'.freeze
+  VERSION = '6.0.0'.freeze
 end


### PR DESCRIPTION
This confirms that the adapter works with ActiveRecord 6.0.

The API arguments for creating a column changed, as well as the adapter's `sql_for_insert`. They have been updated to match AR 6.0.

As part of this change, this DROPS support for AR below 6.0. This is a breaking change.