### PR TITLE
Support ActiveRecord 6.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         ruby: [2.6]
         gemfile:
-          - ar_6_0
+          - ar_6_1
     services:
       postgres:
         image: postgres:16

--- a/Appraisals
+++ b/Appraisals
@@ -1,3 +1,3 @@
-appraise "ar_6_0" do
-  gem 'activerecord', '~> 6.0.0'
+appraise "ar_6_1" do
+  gem 'activerecord', '~> 6.1.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'activerecord', '>= 6.0.0'
+gem 'activerecord', '>= 6.1.0'

--- a/gemfiles/ar_6_1.gemfile
+++ b/gemfiles/ar_6_1.gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
-gem 'activerecord', '~> 6.0.0'
+gem 'activerecord', '~> 6.1.0'
 
 gemspec path: "../"

--- a/lib/odbc_adapter/version.rb
+++ b/lib/odbc_adapter/version.rb
@@ -1,3 +1,3 @@
 module ODBCAdapter
-  VERSION = '6.0.0'.freeze
+  VERSION = '7.0.0'.freeze
 end


### PR DESCRIPTION
This confirms that the adapter works with ActiveRecord 6.1 with Postgres.

As part of this change, this DROPS support for AR below 6.1. This is a breaking change.