### PR TITLE
Test against Ruby 3.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.6]
+        ruby: [3.2]
         gemfile:
           - ar_6_1
     services:

--- a/lib/odbc_adapter/version.rb
+++ b/lib/odbc_adapter/version.rb
@@ -1,3 +1,3 @@
 module ODBCAdapter
-  VERSION = '7.0.0'.freeze
+  VERSION = '8.0.0'.freeze
 end


### PR DESCRIPTION
We want to confirm this adapter works with more recent versions of ruby. This updates the test matrix to ONLY test against Ruby 3.2.

While this makes no code changes, this signals an intent to no longer support Ruby 2.x.