### PR TITLE
Limited Support for ActiveRecord 7.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         ruby: [3.2]
         gemfile:
-          - ar_6_1
+          - ar_7_0
     services:
       postgres:
         image: postgres:16

--- a/Appraisals
+++ b/Appraisals
@@ -1,3 +1,3 @@
-appraise "ar_6_1" do
-  gem 'activerecord', '~> 6.1.0'
+appraise "ar_7_0" do
+  gem 'activerecord', '~> 7.0.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'activerecord', '>= 6.1.0'
+gem 'activerecord', '>= 7.0.0'

--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # ODBCAdapter
 
-[![Build Status](https://travis-ci.org/localytics/odbc_adapter.svg?branch=master)](https://travis-ci.org/localytics/odbc_adapter)
-[![Gem](https://img.shields.io/gem/v/odbc_adapter.svg)](https://rubygems.org/gems/odbc_adapter)
-
 An ActiveRecord ODBC adapter. Master branch is working off of Rails 5.0.1. Previous work has been done to make it compatible with Rails 3.2 and 4.2; for those versions use the 3.2.x or 4.2.x gem releases.
 
 This adapter will work for basic queries for most DBMSs out of the box, without support for migrations. Full support is built-in for MySQL 5 and PostgreSQL 9 databases. You can register your own adapter to get more support for your DBMS using the `ODBCAdapter.register` function.
 
 A lot of this work is based on [OpenLink's ActiveRecord adapter](http://odbc-rails.rubyforge.org/) which works for earlier versions of Rails.
+
+## ActiveRecord 7.0 Compatibility Issues
+
+Currently this is known to not type cast columns out of database queries
+correctly into their proper data types.
 
 ## Installation
 

--- a/gemfiles/ar_7_0.gemfile
+++ b/gemfiles/ar_7_0.gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
-gem 'activerecord', '~> 6.1.0'
+gem 'activerecord', '~> 7.0.0'
 
 gemspec path: "../"

--- a/lib/odbc_adapter/adapters/postgresql_odbc_adapter.rb
+++ b/lib/odbc_adapter/adapters/postgresql_odbc_adapter.rb
@@ -45,18 +45,6 @@ module ODBCAdapter
         [sql, binds]
       end
 
-      def type_cast(value, column)
-        return super unless column
-
-        case value
-        when String
-          return super unless 'bytea' == column.native_type
-          { value: value, format: 1 }
-        else
-          super
-        end
-      end
-
       # Quotes a string, escaping any ' (single quote) and \ (backslash)
       # characters.
       def quote_string(string)

--- a/lib/odbc_adapter/database_statements.rb
+++ b/lib/odbc_adapter/database_statements.rb
@@ -129,7 +129,7 @@ module ODBCAdapter
     end
 
     def prepared_binds(binds)
-      binds.map(&:value_for_database).map { |bind| _type_cast(bind) }
+      binds.map(&:value_for_database).map { |bind| type_cast(bind) }
     end
   end
 end

--- a/lib/odbc_adapter/quoting.rb
+++ b/lib/odbc_adapter/quoting.rb
@@ -28,7 +28,7 @@ module ODBCAdapter
     # sequence, but not all ODBC drivers support them.
     def quoted_date(value)
       if value.acts_like?(:time)
-        zone_conversion_method = ActiveRecord::Base.default_timezone == :utc ? :getutc : :getlocal
+        zone_conversion_method = ActiveRecord.default_timezone == :utc ? :getutc : :getlocal
 
         if value.respond_to?(zone_conversion_method)
           value = value.send(zone_conversion_method)

--- a/lib/odbc_adapter/version.rb
+++ b/lib/odbc_adapter/version.rb
@@ -1,3 +1,3 @@
 module ODBCAdapter
-  VERSION = '8.0.0'.freeze
+  VERSION = '9.0.0'.freeze
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,6 +32,9 @@ end
 class User < ActiveRecord::Base
   has_many :todos, dependent: :destroy
 
+  # Ideally this should be removed with the natural type inference working.
+  attribute :letters, :integer
+
   scope :lots_of_letters, -> { where(arel_table[:letters].gt(10)) }
 
   create(


### PR DESCRIPTION
We know we have complicated compatibility issues with AR 7.2, and are trying to work our way up to that point by getting the test suite we're using to assist with troubleshooting that. We currently use this for connectivity with Snowflake, and are using it with AR 7.1 in production. Our use case is pretty limited to sending raw queries and handling the casting on our own for results.

This transitions us to testing against ActiveRecord 7.0 to move us closer to making those changes to support 7.2. It does so by making the MINIMAL changes for our use case.

⚠️ This INTENTIONALLY limits the usefulness of this gem for generic ODBC connectivity going forward. ⚠️

To support AR 7.0, this:

1. Uses the `type_cast` method for handling binds, rather than the `_type_cast` method. The underscore method was inlined in [c5bf2b4736f2ddafbc477af5b9478dd7143e5466](https://github.com/rails/rails/commit/c5bf2b4736f2ddafbc477af5b9478dd7143e5466). This requires changes to `PostgreSQLODBCAdapter#type_cast` to adhere to the expected public API, in terms of arguments accepted. Because `type_cast` no longer accepts a column, as of [2d821ef0c5356d860eba2d2341b4db71b67f6594](https://github.com/rails/rails/commit/2d821ef0c5356d860eba2d2341b4db71b67f6594), this custom method isn't useful, as it would return `super` without a column.
2. Remove timezone deprecation warning. When running tests against 7.0, we see the following deprecation:

   ```

   DEPRECATION WARNING: ActiveRecord::Base.default_timezone is deprecated and will be removed in Rails 7.1. Use `ActiveRecord.default_timezone` instead.
   ```

A limitation that this currently has is that columns retrieved from the database are not appropriately being cast to their proper data types. To get around this in the test suite, I've modified the model definition in the test helper to explicitly use the Attributes API to tell the AR User class that letters is an integer.

You can see this in `CalculationsTest#test_average`, which would fail without that change. It would be attempting to call `round` on a string, which fails. This intentionally avoids resolving that problem so we can proceed on updating for our very limited use case on more recent versions of ActiveRecord.

There are known mapping changes that occurred between 6.1 and 7.0. However, none of those changes have been beneficial for resolving this bug.

In [2ec207520389f4a6acb393be45bc73cc3815ad76](https://github.com/rails/rails/commit/2ec207520389f4a6acb393be45bc73cc3815ad76), the `type_map` is moved to be private API in the connection adapter.

In [d79fb963603658117fd1d639976c375ea2a8ada3](https://github.com/rails/rails/commit/d79fb963603658117fd1d639976c375ea2a8ada3), the type map is defined statically for improved memory performance.

We can also see how another fork modified this code to support [AR 7.1](https://github.com/springbuk/odbc_adapter/commit/60a6c9dc8a5707af560506a83f2715b7ed9a59aa) (which this is not supporting yet).