### PR TITLE
Update type casting

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,6 @@ This adapter will work for basic queries for most DBMSs out of the box, without 
 
 A lot of this work is based on [OpenLink's ActiveRecord adapter](http://odbc-rails.rubyforge.org/) which works for earlier versions of Rails.
 
-## ActiveRecord 7.0 Compatibility Issues
-
-Currently this is known to not type cast columns out of database queries
-correctly into their proper data types.
-
 ## Installation
 
 Ensure you have the ODBC driver installed on your machine. You will also need the driver for whichever database to which you want ODBC to connect.

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,9 +32,6 @@ end
 class User < ActiveRecord::Base
   has_many :todos, dependent: :destroy
 
-  # Ideally this should be removed with the natural type inference working.
-  attribute :letters, :integer
-
   scope :lots_of_letters, -> { where(arel_table[:letters].gt(10)) }
 
   create(


### PR DESCRIPTION
We recently merged a change that supported ActiveRecord 7.0. However, it was not casting query results back out from the database into the right type. I thought it had to do with the type mapping.

Instead, I found the `dbms_type_cast` method when modifying for AR 7.1. That's because the `exec_query` method is now changing to an internal method as part of that work.

This method is what handles modifying the data to their proper types. I grabbed this implementation from [another fork](https://github.com/springbuk/odbc_adapter/blob/d419e5fac529b1d1dbf193a68c974a8a5bb5c9d1/lib/odbc_adapter/database_statements.rb#L106) of this gem.

This allows me to remove the prior hack, which was explicitly setting the attributes API to allow the tests to pass.