### PR TITLE
ActiveRecord 7.1 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         ruby: [3.2]
         gemfile:
-          - ar_7_0
+          - ar_7_1
     services:
       postgres:
         image: postgres:16

--- a/Appraisals
+++ b/Appraisals
@@ -1,3 +1,3 @@
-appraise "ar_7_0" do
-  gem 'activerecord', '~> 7.0.0'
+appraise "ar_7_1" do
+  gem 'activerecord', '~> 7.1.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'activerecord', '>= 7.0.0'
+gem 'activerecord', '>= 7.1.0'

--- a/gemfiles/ar_7_1.gemfile
+++ b/gemfiles/ar_7_1.gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
-gem 'activerecord', '~> 7.0.0'
+gem 'activerecord', '~> 7.1.0'
 
 gemspec path: "../"

--- a/lib/odbc_adapter/adapters/postgresql_odbc_adapter.rb
+++ b/lib/odbc_adapter/adapters/postgresql_odbc_adapter.rb
@@ -30,19 +30,7 @@ module ODBCAdapter
       # Returns the sequence name for a table's primary key or some other
       # specified key.
       def default_sequence_name(table_name, pk = nil)
-        serial_sequence(table_name, pk || 'id').split('.').last
-      rescue ActiveRecord::StatementInvalid
         "#{table_name}_#{pk || 'id'}_seq"
-      end
-
-      def sql_for_insert(sql, pk, binds)
-        unless pk
-          table_ref = extract_table_ref_from_insert_sql(sql)
-          pk = primary_key(table_ref) if table_ref
-        end
-
-        sql = "#{sql} RETURNING #{quote_column_name(pk)}" if pk
-        [sql, binds]
       end
 
       # Quotes a string, escaping any ' (single quote) and \ (backslash)
@@ -163,15 +151,6 @@ module ODBCAdapter
       def last_insert_id(sequence_name)
         r = exec_query("SELECT currval('#{sequence_name}')", 'SQL')
         Integer(r.rows.first.first)
-      end
-
-      private
-
-      def serial_sequence(table, column)
-        result = exec_query(<<-eosql, 'SCHEMA')
-          SELECT pg_get_serial_sequence('#{table}', '#{column}')
-        eosql
-        result.rows.first.first
       end
     end
   end

--- a/lib/odbc_adapter/database_statements.rb
+++ b/lib/odbc_adapter/database_statements.rb
@@ -10,17 +10,27 @@ module ODBCAdapter
     def execute(sql, name = nil, binds = [])
       log(sql, name) do
         sql = bind_params(binds, sql) if prepared_statements
-        @connection.do(sql)
+        @raw_connection.do(sql)
       end
+    end
+
+    # Executes an INSERT query and returns the new record's ID
+    def insert(arel, name = nil, pk = nil, id_value = nil, sequence_name = nil, binds = [], returning: nil)
+      sql, binds = to_sql_and_binds(arel, binds)
+      exec_insert(sql, name, binds, pk, sequence_name, returning: returning)
+
+      return [id_value] unless returning.nil?
+
+      id_value
     end
 
     # Executes +sql+ statement in the context of this connection using
     # +binds+ as the bind substitutes. +name+ is logged along with
     # the executed +sql+ statement.
-    def exec_query(sql, name = 'SQL', binds = [], prepare: false) # rubocop:disable Lint/UnusedMethodArgument
+    def internal_exec_query(sql, name = 'SQL', binds = [], prepare: false) # rubocop:disable Lint/UnusedMethodArgument
       log(sql, name) do
         sql = bind_params(binds, sql) if prepared_statements
-        stmt =  @connection.run(sql)
+        stmt =  @raw_connection.run(sql)
 
         columns = stmt.columns
         values  = stmt.to_a
@@ -42,20 +52,20 @@ module ODBCAdapter
 
     # Begins the transaction (and turns off auto-committing).
     def begin_db_transaction
-      @connection.autocommit = false
+      @raw_connection.autocommit = false
     end
 
     # Commits the transaction (and turns on auto-committing).
     def commit_db_transaction
-      @connection.commit
-      @connection.autocommit = true
+      @raw_connection.commit
+      @raw_connection.autocommit = true
     end
 
     # Rolls back the transaction (and turns on auto-committing). Must be
     # done if the transaction block raises an exception or returns false.
     def exec_rollback_db_transaction
-      @connection.rollback
-      @connection.autocommit = true
+      @raw_connection.rollback
+      @raw_connection.autocommit = true
     end
 
     # Returns the default sequence name for a table.
@@ -112,8 +122,8 @@ module ODBCAdapter
                         # so that future us can see what they should be
                         value
                       else
-                        # the use of @@connection.types() results in a "was not dropped before garbage collection" warning.
-                        raise "Unknown column type: #{column.type}  #{@connection.types(column.type).first[0]}"
+                        # the use of @@raw_connection.types() results in a "was not dropped before garbage collection" warning.
+                        raise "Unknown column type: #{column.type}  #{@raw_connection.types(column.type).first[0]}"
                       end
 
           row[col_index] = new_value
@@ -177,7 +187,14 @@ module ODBCAdapter
     end
 
     def prepared_binds(binds)
-      binds.map(&:value_for_database).map { |bind| type_cast(bind) }
+      binds.map do |bind|
+        if bind.respond_to?(:value_for_database)
+          bind.value_for_database
+        else
+          bind
+        end
+      end
+        .map { |bind| type_cast(bind) }
     end
   end
 end

--- a/lib/odbc_adapter/schema_statements.rb
+++ b/lib/odbc_adapter/schema_statements.rb
@@ -10,7 +10,7 @@ module ODBCAdapter
     # Returns an array of table names, for database tables visible on the
     # current connection.
     def tables(_name = nil)
-      stmt   = @connection.tables
+      stmt   = @raw_connection.tables
       result = stmt.fetch_all || []
       stmt.drop
 
@@ -28,7 +28,7 @@ module ODBCAdapter
 
     # Returns an array of indexes for the given table.
     def indexes(table_name, _name = nil)
-      stmt   = @connection.indexes(native_case(table_name.to_s))
+      stmt   = @raw_connection.indexes(native_case(table_name.to_s))
       result = stmt.fetch_all || []
       stmt.drop unless stmt.nil?
 
@@ -59,7 +59,7 @@ module ODBCAdapter
     # Returns an array of Column objects for the table specified by
     # +table_name+.
     def columns(table_name, _name = nil)
-      stmt   = @connection.columns(native_case(table_name.to_s))
+      stmt   = @raw_connection.columns(native_case(table_name.to_s))
       result = stmt.fetch_all || []
       stmt.drop
 
@@ -89,14 +89,14 @@ module ODBCAdapter
 
     # Returns just a table's primary key
     def primary_key(table_name)
-      stmt   = @connection.primary_keys(native_case(table_name.to_s))
+      stmt   = @raw_connection.primary_keys(native_case(table_name.to_s))
       result = stmt.fetch_all || []
       stmt.drop unless stmt.nil?
       result[0] && result[0][3]
     end
 
     def foreign_keys(table_name)
-      stmt   = @connection.foreign_keys(native_case(table_name.to_s))
+      stmt   = @raw_connection.foreign_keys(native_case(table_name.to_s))
       result = stmt.fetch_all || []
       stmt.drop unless stmt.nil?
 

--- a/lib/odbc_adapter/version.rb
+++ b/lib/odbc_adapter/version.rb
@@ -1,3 +1,3 @@
 module ODBCAdapter
-  VERSION = '9.0.0'.freeze
+  VERSION = '10.0.0'.freeze
 end

--- a/test/metadata_test.rb
+++ b/test/metadata_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class MetadataTest < Minitest::Test
   def test_data_sources
-    assert_equal %w[ar_internal_metadata todos users], User.connection.data_sources.sort
+    assert_equal %w[ar_internal_metadata schema_migrations todos users], User.connection.data_sources.sort
   end
 
   def test_column_names


### PR DESCRIPTION
This increases the minimum version of ActiveRecord to be used against this to be 7.1. This is no longer compatible with 7.0 after these changes.

The following large-scale modifications have been made to support 7.1:

1. Rename `@connection` instance variable to `@raw_connection`.

In [d86fd6415c0dfce6fadb77e74696cf728e5eb76b](https://github.com/rails/rails/commit/d86fd6415c0dfce6fadb77e74696cf728e5eb76b), the instance variable `@connection` is renamed to `@raw_connection`. This makes the same change throughout the adapter.

> This is unfortunately going to force a change into all external adapter
> subclasses, but I'm going to be making other changes too, so it's not
> the worst of them... and it's just so confusing at the moment to have
> "@connection" sometimes mean the AR adapter and sometimes the inner
> connection, depending on exactly which class we're in.

2. Modify adapter constructor arguments

In [8551e64e2411811f26d210601abdba6e13d8798c](https://github.com/rails/rails/commit/8551e64e2411811f26d210601abdba6e13d8798c), the `AbstractAdapter`'s initializer is changed to, going forward, expect only a configuration hash. However, it still has support for the prior connection attributes. They have been soft-deprecated.

The initializer of this adapter has been changed to adhere to that set of arguments while also adding the database metadata, as it previously did.

Note that this adapter still expects the "old" style of providing all the arguments, and not only the config hash. This means that when that transition eventually happens and the initializer hard-warns, deprecates, and eventually removes the old style, we will be forced to address that then.

3. Define `reconnect` rather than `reconnect!`

In [02f5de1bc93407e878cf4d92e2caf46d4c6e5409](https://github.com/rails/rails/commit/02f5de1bc93407e878cf4d92e2caf46d4c6e5409), the `AbstractAdapter#reconnect!` method expects for a `reconnect` method to exist on any implementations of the adapter. This renames what was the `reconnect!` method in our adapter to instead be the `reconnect` method that `reconnect!` calls.

4. Define `DatabaseStatements#internal_exec_query`

In [942785fb8b03772dde338cc241af8e5de4d2efbc](https://github.com/rails/rails/commit/942785fb8b03772dde338cc241af8e5de4d2efbc) ActiveRecord keeps the `DatabaseStatements#exec_query` public API. However, it delegates the implementation to `internal_exec_query`, as do other methods. The `internal_exec_query` method must be defined by each adapter. This change does so.

5. Modify `DatabaseStatements#prepared_binds`

This is the most curious of these changes, in that I cannot provide justifiable source code explanation on the change. In ActiveRecord 7.0, when binding parameters, the parameter to bind would be an instance of `ActiveRecord::Relation::QueryAttribute`. In 7.1, it appears to be the raw bound value. So, attempting to call `value_for_database` on a symbol or a string or other database does not succeed, as it doesn't respond to that method.

This is at least the case for binding params into queries communicating with Postgres, as this CI test suite currently does.

To avoid this, rather than definitely calling `value_for_database`, we check to see if each bind responds to the method, and if so, then we retrieve `value_for_database`. Otherwise, we pass the bind value directly to be type cast.

I spent a good amount of time looking at the Arel visitors to understand the AST differences between 7.0 and 7.1. I could clearly see there were a different set of visitors used for the same query for this binding. However, it was not clear to be WHY that was the case, or what changes caused that. As such, this feels like not getting at the root cause; however, it does allow us to proceed.

This has been tested internally against an application connecting with Snowflake in addition to passing the tests on CI.