### PR TITLE
Support nil database_metadata in adapter constructor

### DIFF
--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -77,12 +77,17 @@ module ActiveRecord
       # when a connection is first established.
       attr_reader :database_metadata
 
-      def initialize(config_or_deprecated_connection, deprecated_logger = nil, deprecated_connection_options = nil, deprecated_config = nil, database_metadata)
+      def initialize(config_or_deprecated_connection, deprecated_logger = nil, deprecated_connection_options = nil, deprecated_config = nil, database_metadata = nil)
         super(config_or_deprecated_connection, deprecated_logger, deprecated_connection_options, deprecated_config)
-
-        configure_time_options(config_or_deprecated_connection)
-        @database_metadata = database_metadata
         @raw_connection = config_or_deprecated_connection
+
+        if database_metadata
+          @database_metadata = database_metadata
+        else
+          @database_metadata = ::ODBCAdapter::DatabaseMetadata.new(@raw_connection)
+        end
+
+        configure_time_options(@raw_connection)
       end
 
       # Returns the human-readable name of the adapter.


### PR DESCRIPTION
The addition of the database_metadata attribute is not part of the standard constructor that ActiveRecord may expect. It's added by this adapter specifically so `ActiveRecord::Base.odbc_connection` can pass the already constructed database metadata to the constructor.

Because the rest of ActiveRecord will not send it, this defaults the attribute to nil. When it's not provided, we construct it based on the connection.