### PR TITLE
Extract connection setup

### DIFF
--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -10,6 +10,7 @@ require 'odbc_adapter/schema_statements'
 
 require 'odbc_adapter/column'
 require 'odbc_adapter/column_metadata'
+require 'odbc_adapter/connection_setup'
 require 'odbc_adapter/database_metadata'
 require 'odbc_adapter/registry'
 require 'odbc_adapter/version'
@@ -20,41 +21,11 @@ module ActiveRecord
       # Build a new ODBC connection with the given configuration.
       def odbc_connection(config)
         config = config.symbolize_keys
+        setup = ::ODBCAdapter::ConnectionSetup.new(config.symbolize_keys)
+        setup.build
 
-        connection, config =
-          if config.key?(:dsn)
-            odbc_dsn_connection(config)
-          elsif config.key?(:conn_str)
-            odbc_conn_str_connection(config)
-          else
-            raise ArgumentError, 'No data source name (:dsn) or connection string (:conn_str) specified.'
-          end
-
-        database_metadata = ::ODBCAdapter::DatabaseMetadata.new(connection)
-        database_metadata.adapter_class.new(connection, logger, nil, config, database_metadata)
-      end
-
-      private
-
-      # Connect using a predefined DSN.
-      def odbc_dsn_connection(config)
-        username   = config[:username] ? config[:username].to_s : nil
-        password   = config[:password] ? config[:password].to_s : nil
-        connection = ODBC.connect(config[:dsn], username, password)
-        [connection, config.merge(username: username, password: password)]
-      end
-
-      # Connect using ODBC connection string
-      # Supports DSN-based or DSN-less connections
-      # e.g. "DSN=virt5;UID=rails;PWD=rails"
-      #      "DRIVER={OpenLink Virtuoso};HOST=carlmbp;UID=rails;PWD=rails"
-      def odbc_conn_str_connection(config)
-        driver = ODBC::Driver.new
-        driver.name = 'odbc'
-        driver.attrs = config[:conn_str].split(';').map { |option| option.split('=', 2) }.to_h
-
-        connection = ODBC::Database.new.drvconnect(driver)
-        [connection, config.merge(driver: driver)]
+        database_metadata = ::ODBCAdapter::DatabaseMetadata.new(setup.connection)
+        database_metadata.adapter_class.new(setup.connection, logger, nil, setup.config, database_metadata)
       end
     end
   end

--- a/lib/odbc_adapter/connection_setup.rb
+++ b/lib/odbc_adapter/connection_setup.rb
@@ -1,0 +1,44 @@
+module ODBCAdapter
+  class ConnectionSetup
+    attr_reader :config
+    attr_reader :connection
+
+    def initialize(config)
+      @config = config
+      @connection = nil
+    end
+
+    def build
+      if @config.key?(:dsn)
+        odbc_dsn_connection
+      elsif @config.key?(:conn_str)
+        odbc_conn_str_connection
+      else
+        raise ArgumentError, 'No data source name (:dsn) or connection string (:conn_str) specified.'
+      end
+    end
+
+    private
+
+    # Connect using a predefined DSN.
+    def odbc_dsn_connection
+      username   = @config[:username] ? @config[:username].to_s : nil
+      password   = @config[:password] ? @config[:password].to_s : nil
+      @connection = ODBC.connect(config[:dsn], username, password)
+      @config.merge!(username: username, password: password)
+    end
+
+    # Connect using ODBC connection string
+    # Supports DSN-based or DSN-less connections
+    # e.g. "DSN=virt5;UID=rails;PWD=rails"
+    #      "DRIVER={OpenLink Virtuoso};HOST=carlmbp;UID=rails;PWD=rails"
+    def odbc_conn_str_connection
+      driver = ODBC::Driver.new
+      driver.name = 'odbc'
+      driver.attrs = @config[:conn_str].split(';').map { |option| option.split('=', 2) }.to_h
+
+      @connection = ODBC::Database.new.drvconnect(driver)
+      @config.merge!(driver: driver)
+    end
+  end
+end

--- a/test/connection_setup_test.rb
+++ b/test/connection_setup_test.rb
@@ -1,0 +1,67 @@
+require 'test_helper'
+
+class ConnectionSetupTest < Minitest::Test
+  def test_build_dsn_connection
+    config = {
+      dsn: "dsn",
+      username: "foo",
+      password: "bar",
+    }
+
+    ODBC.stub :connect, "here's your connection" do
+      setup = ODBCAdapter::ConnectionSetup.new(config)
+      setup.build
+
+      assert_equal "foo", setup.config[:username]
+      assert_equal "bar", setup.config[:password]
+
+      assert_equal "here's your connection", setup.connection
+    end
+  end
+
+  def test_build_conn_str_connection
+    mock_database = MockDatabase.new
+    ODBC::Database.stub :new, mock_database do
+      config = {
+        conn_str: "DRIVER={PostgreSQL ANSI};SERVER=127.0.0.1;PORT=5432;DATABASE=db;UID=user;password=password"
+      }
+      setup = ODBCAdapter::ConnectionSetup.new(config)
+      setup.build
+
+      assert_equal "odbc", setup.config[:driver].name
+      assert_equal setup.config[:driver], mock_database.driver
+
+      expected_driver_attrs = {
+        "DRIVER"=>"{PostgreSQL ANSI}",
+        "SERVER"=>"127.0.0.1",
+        "PORT"=>"5432",
+        "DATABASE"=>"db",
+        "UID"=>"user",
+        "password"=>"password",
+      }
+      assert_equal expected_driver_attrs, setup.config[:driver].attrs
+
+      assert_equal "here's your connection", setup.connection
+    end
+  end
+
+  def test_build_raises_for_unknown_config
+    setup = ODBCAdapter::ConnectionSetup.new({})
+
+    expected_error_message = "No data source name (:dsn) or connection string (:conn_str) specified."
+    assert_raises(ArgumentError, expected_error_message) { setup.build }
+  end
+
+  class MockDatabase
+    attr_reader :driver
+
+    def initialize
+      @driver = nil
+    end
+
+    def drvconnect(driver)
+      @driver = driver
+      "here's your connection"
+    end
+  end
+end


### PR DESCRIPTION
ActiveRecord 7.2 includes changes with how an adapter is created. As a result, it's likely that the work that's done in
`ActiveRecord::Base.odbc_connection` will move or be re-used in additional locations to support 7.2.

To get ahead of this, the logic to build the connection and modify the configuration is extracted to a separate class that is individually tested.