### PR TITLE
Pin adapter to Rails 7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'activerecord', '>= 7.1.0'
+gem 'activerecord', '= 7.1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'activerecord', '= 7.1.0'
+gem 'activerecord', '~> 7.1.0'


### PR DESCRIPTION
I'm running into a minor footgun locally where I'm trying to run tests on my branch and master to compare differences but I need to explicitly specify I want Rails 7.1 on master.

To make this a little more convenient in the short term, I'd like to pin our rails version to 7.1. We can change this once the adapter is working on 7.2+ 