### PR TITLE
Limit ActiveRecord to be below 8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'activerecord', '>= 7.1.0'
+gem 'activerecord', '>= 7.1.0', '< 8.0.0'
 gem 'pg', '~> 1.1'


### PR DESCRIPTION
Right now we do not support ActiveRecord 8, so let's define this limitation. Otherwise, fresh installs are going to pull 8.x.x.