### PR TITLE
Install drivers on CI before setting up ruby

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,13 +29,13 @@ jobs:
       BUNDLE_PATH_RELATIVE_TO_CWD: true
     steps:
       - uses: actions/checkout@v3
+      - name: Install ODBC drivers
+        run: sudo apt-get install unixodbc unixodbc-dev odbc-postgresql
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
           ruby-version: ${{ matrix.ruby }}
-      - name: Install ODBC drivers
-        run: sudo apt-get install unixodbc unixodbc-dev odbc-postgresql
       - name: Install dependencies
         run: bundle install
       - name: driver setup


### PR DESCRIPTION
Running the setup-ruby step will bundle the dependencies. In order for the ruby odbc gem to install correctly, we must have unixodbc available.

This moves the step to install the drivers and system dependencies BEFORE setting up ruby.