### PR TITLE
Explicitly support Rails 8.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [3.2]
-        gemfile: [ar_7_1, ar_7_2]
+        gemfile: [ar_7_1, ar_7_2, ar_8_0]
     services:
       postgres:
         image: postgres:16

--- a/Appraisals
+++ b/Appraisals
@@ -1,3 +1,11 @@
 appraise "ar_7_1" do
   gem 'activerecord', '~> 7.1.0'
 end
+
+appraise "ar_7_2" do
+  gem 'activerecord', '~> 7.2.0'
+end
+
+appraise "ar_8_0" do
+  gem 'activerecord', '~> 8.0.0'
+end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Pending
+
+* Explicitly support Rails 8.0
+
 # 10.1.0
 
 * Adds backwards-compatible support for Rails 7.2

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'activerecord', '>= 7.1.0', '< 8.0.0'
+gem 'activerecord', '>= 7.1.0'
 gem 'pg', '~> 1.1'

--- a/gemfiles/ar_8_0.gemfile
+++ b/gemfiles/ar_8_0.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+gem 'activerecord', '~> 8.0.0'
+gem 'pg', '~> 1.1'
+
+gemspec path: "../"


### PR DESCRIPTION
There was some confusion around whether or not this adapter supports Rails 8.0. After testing locally and in CI, it looks like it does so I'm updating the Gemfile accordingly. We'll also run tests on Rails 8.0 going forward