### PR TITLE
Add support for ActiveRecord 8.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [3.3, 3.4]
-        gemfile: [ar_7_2, ar_8_0]
+        gemfile: [ar_7_2, ar_8_0, ar_8_1]
     services:
       postgres:
         image: postgres:16

--- a/Appraisals
+++ b/Appraisals
@@ -5,3 +5,7 @@ end
 appraise "ar_8_0" do
   gem 'activerecord', '~> 8.0.0'
 end
+
+appraise "ar_8_1" do
+  gem 'activerecord', '~> 8.1.0'
+end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Pending
 
-* Explicitly support Rails 8.1
+# 11.0.0
+
 * Drop support for Rails 7.1
 * Drop support for Ruby 3.2.
-* Test against Ruby 3.4.
 * Test against Ruby 3.3.
+* Test against Ruby 3.4.
 * Explicitly support Rails 8.0
+* Explicitly support Rails 8.1
 
 # 10.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Pending
 
+* Explicitly support Rails 8.1
 * Drop support for Rails 7.1
 * Drop support for Ruby 3.2.
 * Test against Ruby 3.4.

--- a/gemfiles/ar_8_1.gemfile
+++ b/gemfiles/ar_8_1.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+gem 'activerecord', '~> 8.1.0'
+gem 'pg', '~> 1.1'
+
+gemspec path: "../"

--- a/lib/odbc_adapter/column.rb
+++ b/lib/odbc_adapter/column.rb
@@ -5,9 +5,16 @@ module ODBCAdapter
     # Add the native_type accessor to allow the native DBMS to report back what
     # it uses to represent the column internally.
     # rubocop:disable Metrics/ParameterLists
-    def initialize(name, default, sql_type_metadata = nil, null = true, native_type = nil, **kwargs)
-      super(name, default, sql_type_metadata, null, **kwargs)
-      @native_type = native_type
+    if ODBCAdapter::BEFORE_RAILS_8_1
+      def initialize(name, default, sql_type_metadata = nil, null = true, native_type = nil, **kwargs)
+        super(name, default, sql_type_metadata, null, **kwargs)
+        @native_type = native_type
+      end
+    else
+      def initialize(name, cast_type, default, sql_type_metadata = nil, null = true, native_type = nil, **kwargs)
+        super(name, cast_type, default, sql_type_metadata, null, **kwargs)
+        @native_type = native_type
+      end
     end
   end
 end

--- a/lib/odbc_adapter/version.rb
+++ b/lib/odbc_adapter/version.rb
@@ -7,5 +7,5 @@ module ODBCAdapter
   # - Create a tag for this release:
   #   1. `git tag v{YOUR-VERSION-NUMBER}`
   #   2. `git push origin --tags`
-  VERSION = '10.1.0'.freeze
+  VERSION = '11.0.0'.freeze
 end


### PR DESCRIPTION
With the release of Rails 8.1, we want to test that this adapter works with ActiveRecord 8.1.